### PR TITLE
feat(use-business): Implements use-business

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Wilhelm Behncke <wilhelm.behncke@openformation.io>
+Henrik Radandt <henrik.radandt@openformation.io>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 </p>
 
-
 # @openformation/react-hooks
 
 > Common react hooks for web application development
@@ -15,10 +14,11 @@ This package is still under development. This message will disappear once the pa
 
 ## Packages
 
-| package name | stability | description | Link to README |
-|-|-|-|-|
-| `@openformation/react-hooks` | pre-alpha | Aggregate package containing all hooks | [README](./packages/react-hooks/README.md) |
-| `@openformation/use-service` | pre-alpha | Bind services to a react component instance | [README](./packages/use-service/README.md) |
+| package name                  | stability | description                                           | Link to README                              |
+| ----------------------------- | --------- | ----------------------------------------------------- | ------------------------------------------- |
+| `@openformation/react-hooks`  | pre-alpha | Aggregate package containing all hooks                | [README](./packages/react-hooks/README.md)  |
+| `@openformation/use-business` | pre-alpha | Handle busy state for multiple asynchronous processes | [README](./packages/use-business/README.md) |
+| `@openformation/use-service`  | pre-alpha | Bind services to a react component instance           | [README](./packages/use-service/README.md)  |
 
 ## LICENSE
 

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -10,6 +10,7 @@
     "build:cjs": "rm -rf ./lib/cjs && tsc -p tsconfig.cjs.json"
   },
   "dependencies": {
+    "@openformation/use-business": "workspace:*",
     "@openformation/use-service": "workspace:*"
   },
   "keywords": ["react", "hooks"],

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -11,4 +11,5 @@
  *
  */
 
+export { useBusiness } from "@openformation/use-business";
 export { useService } from "@openformation/use-service";

--- a/packages/react-hooks/tsconfig.cjs.json
+++ b/packages/react-hooks/tsconfig.cjs.json
@@ -6,6 +6,9 @@
   },
   "references": [
     {
+      "path": "../use-business"
+    },
+    {
       "path": "../use-service"
     }
   ]

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -6,6 +6,9 @@
   },
   "references": [
     {
+      "path": "../use-business"
+    },
+    {
       "path": "../use-service"
     }
   ],

--- a/packages/use-business/.gitignore
+++ b/packages/use-business/.gitignore
@@ -1,0 +1,2 @@
+lib/
+tsconfig.tsbuildinfo

--- a/packages/use-business/LICENSE
+++ b/packages/use-business/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Open Formation GmbH.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/use-business/README.md
+++ b/packages/use-business/README.md
@@ -1,0 +1,82 @@
+<p align="center">
+
+<img width="250" src="./hooks.svg" alt="Two fishing hooks">
+
+</p>
+
+# @openformation/use-business
+
+> Handle busy state for multiple asynchronous processes
+
+## Installation
+
+Using npm:
+
+```
+npm install --save @openformation/use-business
+```
+
+Using yarn:
+
+```
+yarn add @openformation/use-business
+```
+
+Using pnpm:
+
+```
+pnpm add --save @openformation/use-business
+```
+
+## API
+
+```typescript
+useBusiness = () => Business;
+
+interface Business {
+  readonly isBusy: boolean;
+  perform<R>(processFn: () => Promise<R>): R;
+}
+```
+
+## Usage
+
+```typescript
+const LoadMoreList = <I>(props: {
+  loadItems: (page: number) => Promise<I[]>;
+  renderItem: (item: I) => React.ReactNode;
+}) => {
+  const [items, setItems] = React.useState<I[]>([]);
+  const [page, setPage] = React.useState(0);
+  const business = useBusiness();
+  const loadMore = Reac.useCallback(() => setPage((page) => page + 1), [
+    setPage,
+  ]);
+
+  React.useEffect(async () => {
+    const loadedItems = await business.perform(() => props.loadItems(page));
+
+    setItems((items) => [...items, ...loadedItems]);
+  }, [page]);
+
+  return (
+    <>
+      <ul>
+        {items.map((item, index) => (
+          <li key={String(index)}>
+            {renderItem(item)}
+          </li>
+        ))}
+        {business.isBusy ? <li key="loading">Loading...</li> : null}
+      </ul>
+      <button onClick={loadMore}>
+        Load more
+      </button>
+    </>
+  );
+};
+```
+
+## LICENSE
+
+see [LICENSE](./LICENSE)

--- a/packages/use-business/README.md
+++ b/packages/use-business/README.md
@@ -51,7 +51,7 @@ const LoadMoreList = <I>(props: {
   const [items, setItems] = React.useState<I[]>([]);
   const [page, setPage] = React.useState(0);
   const business = useBusiness();
-  const loadMore = Reac.useCallback(() => setPage((page) => page + 1), [
+  const loadMore = React.useCallback(() => setPage((page) => page + 1), [
     setPage,
   ]);
 
@@ -92,7 +92,7 @@ const LoadMoreList = <I>(props: {
   const [items, setItems] = React.useState<I[]>([]);
   const [page, setPage] = React.useState(0);
   const business = useBusiness();
-  const loadMore = Reac.useCallback(() => setPage((page) => page + 1), [
+  const loadMore = React.useCallback(() => setPage((page) => page + 1), [
     setPage,
   ]);
 

--- a/packages/use-business/README.md
+++ b/packages/use-business/README.md
@@ -59,7 +59,7 @@ const LoadMoreList = <I>(props: {
     const loadedItems = await props.loadItems(page);
 
     setItems((items) => [...items, ...loadedItems]);
-  }, [page]);
+}, [page, setItems]);
 
   return (
     <>
@@ -100,7 +100,7 @@ const LoadMoreList = <I>(props: {
     const loadedItems = await business.perform(() => props.loadItems(page));
 
     setItems((items) => [...items, ...loadedItems]);
-  }, [page]);
+  }, [page, setItems]);
 
   return (
     <>

--- a/packages/use-business/README.md
+++ b/packages/use-business/README.md
@@ -41,6 +41,49 @@ interface Business {
 
 ## Usage
 
+Let's say, we have a component `LoadMoreList` that renders a list of items and is able to fetch more items with a touch of a button and add them to the list:
+
+```typescript
+const LoadMoreList = <I>(props: {
+  loadItems: (page: number) => Promise<I[]>;
+  renderItem: (item: I) => React.ReactNode;
+}) => {
+  const [items, setItems] = React.useState<I[]>([]);
+  const [page, setPage] = React.useState(0);
+  const business = useBusiness();
+  const loadMore = Reac.useCallback(() => setPage((page) => page + 1), [
+    setPage,
+  ]);
+
+  React.useEffect(async () => {
+    const loadedItems = await props.loadItems(page);
+
+    setItems((items) => [...items, ...loadedItems]);
+  }, [page]);
+
+  return (
+    <>
+      <ul>
+        {items.map((item, index) => (
+          <li key={String(index)}>
+            {renderItem(item)}
+          </li>
+        ))}
+      </ul>
+      <button onClick={loadMore}>
+        Load more
+      </button>
+    </>
+  );
+};
+```
+
+Because `loadItems` may take a while, we now want to show a loading Indicator while it's running. Also, the button should be disabled while new items are being loaded to prevent weird behavior through too many clicks and parallel fetching.
+
+This is where `useBusiness` comes in. It provides a function `perform` that can be wrapped around the call to any process that returns a `Promise`. It also exposes a property `isBusy` that'll be `true` as long as any `Promise` that has been started is still running.
+
+The integration looks like this:
+
 ```typescript
 const LoadMoreList = <I>(props: {
   loadItems: (page: number) => Promise<I[]>;
@@ -69,13 +112,15 @@ const LoadMoreList = <I>(props: {
         ))}
         {business.isBusy ? <li key="loading">Loading...</li> : null}
       </ul>
-      <button onClick={loadMore}>
+      <button onClick={loadMore} disabled={business.isBusy}>
         Load more
       </button>
     </>
   );
 };
 ```
+
+**Hint:** If `perform` was called multiple times, `isBusy` stays `true` until all `Promises` are settled.
 
 ## LICENSE
 

--- a/packages/use-business/jest.config.js
+++ b/packages/use-business/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import("ts-jest/dist/types").InitialOptionsTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+};

--- a/packages/use-business/package.json
+++ b/packages/use-business/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openformation/use-business",
+  "version": "1.0.0",
+  "description": "Handle busy state for multiple asynchronous processes",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "scripts": {
+    "build": "rm -rf ./lib && pnpm run build:esm && pnpm run build:cjs",
+    "build:esm": "rm -rf ./lib/esm && tsc",
+    "build:cjs": "rm -rf ./lib/cjs && tsc -p tsconfig.cjs.json",
+    "test": "jest --verbose src/"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "react": "^18.0.0"
+  }
+}

--- a/packages/use-business/src/index.ts
+++ b/packages/use-business/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Open Formation GmbH.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ *
+ */
+
+export { useBusiness } from "./useBusiness";

--- a/packages/use-business/src/useBusiness.spec.ts
+++ b/packages/use-business/src/useBusiness.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Open Formation GmbH.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ *
+ */
+
+import { renderHook, act } from "@testing-library/react-hooks";
+
+import { useBusiness } from "./useBusiness";
+
+describe("useBusiness", () => {
+  it("isn't busy initially", () => {
+    const { result } = renderHook(() => useBusiness());
+
+    expect(result.current.isBusy).toBe(false);
+  });
+
+  it("turns busy when a process is performed and stays busy until that process is finished", async () => {
+    const { result } = renderHook(() => useBusiness());
+    let process: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      process = result.current.perform(
+        () => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+    });
+
+    expect(result.current.isBusy).toBe(true);
+
+    await act(() => process);
+
+    expect(result.current.isBusy).toBe(false);
+  });
+
+  it("stays busy until all started processes are finished", async () => {
+    const { result } = renderHook(() => useBusiness());
+    let process1: Promise<void> = Promise.resolve();
+    let process2: Promise<void> = Promise.resolve();
+    let process3: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      process1 = result.current.perform(
+        () => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+      process2 = result.current.perform(
+        () => new Promise((resolve) => setTimeout(resolve, 200))
+      );
+      process3 = result.current.perform(
+        () => new Promise((resolve) => setTimeout(resolve, 300))
+      );
+    });
+
+    expect(result.current.isBusy).toBe(true);
+
+    await act(() => process1);
+
+    expect(result.current.isBusy).toBe(true);
+
+    await act(() => process2);
+
+    expect(result.current.isBusy).toBe(true);
+
+    await act(() => process3);
+
+    expect(result.current.isBusy).toBe(false);
+  });
+});

--- a/packages/use-business/src/useBusiness.ts
+++ b/packages/use-business/src/useBusiness.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Open Formation GmbH.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ */
+
+import * as React from "react";
+
+export const useBusiness = () => {
+  const [processes, setProcesses] = React.useState(new Set());
+  const mounted = React.useRef(true);
+
+  const perform = React.useCallback(
+    <R>(processFn: () => Promise<R>) => {
+      const process = processFn().finally(() => {
+        if (mounted.current) {
+          setProcesses((processes) => {
+            const nextProcesses = new Set([...processes]);
+            nextProcesses.delete(process);
+            return nextProcesses;
+          });
+        }
+      });
+
+      setProcesses((processes) => new Set([...processes, process]));
+
+      return process;
+    },
+    [setProcesses],
+  );
+
+  React.useEffect(() => {
+    mounted.current = true;
+
+    return () => {
+      mounted.current = false;
+    };
+  });
+
+  return Object.freeze({
+    isBusy: processes.size > 0,
+    perform,
+  });
+};

--- a/packages/use-business/tsconfig.cjs.json
+++ b/packages/use-business/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/cjs/",
+    "module": "CommonJS"
+  }
+}

--- a/packages/use-business/tsconfig.json
+++ b/packages/use-business/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src/",
+    "outDir": "./lib/esm/"
+  },
+  "exclude": [
+    "node_modules",
+    "lib",
+    "src/**/*.spec.ts"
+  ],
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,10 @@ importers:
 
   packages/react-hooks:
     specifiers:
+      '@openformation/use-business': workspace:*
       '@openformation/use-service': workspace:*
     dependencies:
+      '@openformation/use-business': link:../use-business
       '@openformation/use-service': link:../use-service
 
   packages/use-business:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
     dependencies:
       '@openformation/use-service': link:../use-service
 
+  packages/use-business:
+    specifiers: {}
+
   packages/use-service:
     specifiers: {}
 


### PR DESCRIPTION
`useBusiness` provides a function `perform` that can be wrapped around a call to any process that returns a `Promise`. It also exposes a property `isBusy` that'll be `true` as long as any `Promise` that has been started is still running.

If `perform` gets called multiple times, `isBusy` stays `true` until all `Promises` are settled.

An example use case looks like this:
```typescript
const LoadMoreList = <I>(props: {
  loadItems: (page: number) => Promise<I[]>;
  renderItem: (item: I) => React.ReactNode;
}) => {
  const [items, setItems] = React.useState<I[]>([]);
  const [page, setPage] = React.useState(0);
  const business = useBusiness();
  const loadMore = Reac.useCallback(() => setPage((page) => page + 1), [
    setPage,
  ]);

  React.useEffect(async () => {
    const loadedItems = await business.perform(() => props.loadItems(page));

    setItems((items) => [...items, ...loadedItems]);
  }, [page]);

  return (
    <>
      <ul>
        {items.map((item, index) => (
          <li key={String(index)}>
            {renderItem(item)}
          </li>
        ))}
        {business.isBusy ? <li key="loading">Loading...</li> : null}
      </ul>
      <button onClick={loadMore} disabled={business.isBusy}>
        Load more
      </button>
    </>
  );
};
```