### PR TITLE
chore: Adds linting + clean & nuke scripts

### DIFF
--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -16,6 +16,8 @@ jobs:
           curl -L https://get.pnpm.io/v6.js | node - add --global pnpm@next npm@7
       - name: Install dependencies
         run: pnpm install
+      - name: Lint code base
+        run: pnpm run lint
       - name: Run tests
         run: pnpm run test
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+lib
 .pnpm-debug.log

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint-staged

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This package is still under development. This message will disappear once the pa
 
 ## Packages
 
-| package name                   | stability | description                                           | Link to README                               |
-| ------------------------------ | --------- | ----------------------------------------------------- | -------------------------------------------- |
-| `@openformation/react-hooks`   | pre-alpha | Aggregate package containing all hooks                | [README](./packages/react-hooks/README.md)   |
-| `@openformation/use-business`  | pre-alpha | Handle busy state for multiple asynchronous processes | [README](./packages/use-business/README.md)  |
-| `@openformation/use-service`   | pre-alpha | Bind services to a react component instance           | [README](./packages/use-service/README.md)   |
-| `@openformation/use-pagination`| pre-alpha | Setup a pagination context and exposes api            | [README](./packages/use-pagination/README.md)|
+| package name                    | stability | description                                           | Link to README                                |
+| ------------------------------- | --------- | ----------------------------------------------------- | --------------------------------------------- |
+| `@openformation/react-hooks`    | pre-alpha | Aggregate package containing all hooks                | [README](./packages/react-hooks/README.md)    |
+| `@openformation/use-business`   | pre-alpha | Handle busy state for multiple asynchronous processes | [README](./packages/use-business/README.md)   |
+| `@openformation/use-service`    | pre-alpha | Bind services to a react component instance           | [README](./packages/use-service/README.md)    |
+| `@openformation/use-pagination` | pre-alpha | Setup a pagination context and exposes api            | [README](./packages/use-pagination/README.md) |
 
 ## LICENSE
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "build": "pnpm recursive run --stream build",
-    "test": "pnpm recursive run --stream test",
-    "lint": "pnpm lint:editorconfig && pnpm lint:prettier",
-    "lint:editorconfig": "editorconfig-checker",
-    "lint:prettier": "prettier --check **/*.{ts,tsx,js,json,css,md} --ignore-path .gitignore"
+    "build": "./scripts/build",
+    "lint": "./scripts/lint",
+    "test": "./scripts/test"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "build": "./scripts/build",
+    "clean": "./scripts/clean",
     "lint": "./scripts/lint",
     "test": "./scripts/test"
   },

--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
     "nuke": "./scripts/nuke",
     "test": "./scripts/test"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
     "**/*.{ts,tsx,js,json,css,md}": [
       "prettier --write"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build": "./scripts/build",
     "clean": "./scripts/clean",
     "lint": "./scripts/lint",
+    "nuke": "./scripts/nuke",
     "test": "./scripts/test"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,30 @@
   "private": true,
   "scripts": {
     "build": "pnpm recursive run --stream build",
-    "test": "pnpm recursive run --stream test"
+    "test": "pnpm recursive run --stream test",
+    "lint": "pnpm lint:editorconfig && pnpm lint:prettier",
+    "lint:editorconfig": "editorconfig-checker",
+    "lint:prettier": "prettier --check **/*.{ts,tsx,js,json,css,md} --ignore-path .gitignore"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "**/*.{ts,tsx,js,json,css,md}": [
+      "prettier --write"
+    ]
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.23",
     "@types/react": "^18.0.1",
+    "editorconfig-checker": "^4.0.2",
+    "husky": "^7.0.4",
     "jest": "^27.5.1",
+    "lint-staged": "^12.4.0",
     "prettier": "^2.6.2",
     "react": "^18.0.0",
     "react-test-renderer": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "postinstall": "husky install",
     "build": "./scripts/build",
     "clean": "./scripts/clean",
     "lint": "./scripts/lint",

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -4,7 +4,6 @@
 
 </p>
 
-
 # @openformation/react-hooks
 
 > Common react hooks for web application development

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "rm -rf ./lib && pnpm run build:esm && pnpm run build:cjs",
     "build:esm": "rm -rf ./lib/esm && tsc",
-    "build:cjs": "rm -rf ./lib/cjs && tsc -p tsconfig.cjs.json"
+    "build:cjs": "rm -rf ./lib/cjs && tsc -p tsconfig.cjs.json",
+    "clean": "rm -rf ./lib"
   },
   "dependencies": {
     "@openformation/use-business": "workspace:*",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -14,7 +14,10 @@
     "@openformation/use-service": "workspace:*",
     "@openformation/use-pagination": "workspace:*"
   },
-  "keywords": ["react", "hooks"],
+  "keywords": [
+    "react",
+    "hooks"
+  ],
   "author": "",
   "license": "MIT"
 }

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src/",
-    "outDir": "./lib/esm/",
+    "outDir": "./lib/esm/"
   },
   "references": [
     {
@@ -15,11 +15,6 @@
       "path": "../use-pagination"
     }
   ],
-  "exclude": [
-    "node_modules",
-    "lib",
-  ],
-  "include": [
-    "**/*.ts"
-  ]
+  "exclude": ["node_modules", "lib"],
+  "include": ["**/*.ts"]
 }

--- a/packages/use-business/src/useBusiness.ts
+++ b/packages/use-business/src/useBusiness.ts
@@ -32,7 +32,7 @@ export const useBusiness = () => {
 
       return process;
     },
-    [setProcesses],
+    [setProcesses]
   );
 
   React.useEffect(() => {

--- a/packages/use-business/tsconfig.json
+++ b/packages/use-business/tsconfig.json
@@ -4,12 +4,6 @@
     "rootDir": "./src/",
     "outDir": "./lib/esm/"
   },
-  "exclude": [
-    "node_modules",
-    "lib",
-    "src/**/*.spec.ts"
-  ],
-  "include": [
-    "src/**/*.ts"
-  ]
+  "exclude": ["node_modules", "lib", "src/**/*.spec.ts"],
+  "include": ["src/**/*.ts"]
 }

--- a/packages/use-pagination/README.md
+++ b/packages/use-pagination/README.md
@@ -42,21 +42,21 @@ usePagination = (spec: {
   setCurrent: (nextValue: number) => void,
   next: () => void,
   prev: () => void,
-  hasNext: () => boolean, 
-  hasPrev: () => boolean, 
+  hasNext: () => boolean,
+  hasPrev: () => boolean,
 }
 ```
 
 `initial` is the page value, pagination will start to work at. If this value hurts the boundaries given by `min` and/or `max`, it internally gets clamped to fit the closest boundary.
-*Optional, default value is 0.*
+_Optional, default value is 0._
 
-`min` & `max` define the boundaries for the value that `current` can take. 
-*Optional, default values are `-Infinity` for `min` and `Infinity` for `max`*
+`min` & `max` define the boundaries for the value that `current` can take.
+_Optional, default values are `-Infinity` for `min` and `Infinity` for `max`_
 
 `steps` is the amount that `current` will be increased or decreased by, using `next` or `prev` respectively. The boundaries set by `min` and/or `max` will be respected for those operations.
-*Optional, default value is 1.*
- 
-*Returned API*
+_Optional, default value is 1._
+
+_Returned API_
 
 `current` is the current page value itself.
 
@@ -72,14 +72,14 @@ usePagination = (spec: {
 
 ## Usage
 
-Pagination is a widely used UX pattern in web development, so an implementation should be easy to do. 
+Pagination is a widely used UX pattern in web development, so an implementation should be easy to do.
 
 Another use-case could be a slidable.
 
 ```typescript
 const SlideShow: React.FC<{
-  slides: Slide[], 
-}> = props => {
+  slides: Slide[];
+}> = (props) => {
   const { prev, next, hasPrev, hasNext, setCurrent, current } = usePagination({
     initial: 0,
     min: 0,
@@ -88,22 +88,17 @@ const SlideShow: React.FC<{
 
   return (
     <SlideView>
-      <RowWithSlides slideTo={current}>
-        {props.slides.map(Slide)}
-      </RowWithSlides>
+      <RowWithSlides slideTo={current}>{props.slides.map(Slide)}</RowWithSlides>
       <Thumbs>
         {props.slides.map((slide, index) => (
-          <Thumb 
-            key={index}
-            onClick={() => setCurrent(index)}
-          />
+          <Thumb key={index} onClick={() => setCurrent(index)} />
         ))}
       </Thumbs>
       <PrevButton onClick={prev} disabled={!hasPrev()} />
       <NextButton onClick={next} disabled={!hasNext()} />
     </SlideView>
   );
-}
+};
 ```
 
 A not as obvious use-case is a tab-system.

--- a/packages/use-pagination/src/usePagination.spec.ts
+++ b/packages/use-pagination/src/usePagination.spec.ts
@@ -36,69 +36,83 @@ describe("usePagination", () => {
   });
 
   it("adjusts initial value to fit boundaries", () => {
-    const { result: resultForTooLowInitialValue } = renderHook(() => usePagination({
-      initial: 5,
-      min: 10
-    }));
+    const { result: resultForTooLowInitialValue } = renderHook(() =>
+      usePagination({
+        initial: 5,
+        min: 10,
+      })
+    );
 
-    const { result: resultForTooHighInitialValue } = renderHook(() => usePagination({
-      initial: 5,
-      max: 3
-    }));
+    const { result: resultForTooHighInitialValue } = renderHook(() =>
+      usePagination({
+        initial: 5,
+        max: 3,
+      })
+    );
 
     expect(resultForTooLowInitialValue.current.current).toBe(10);
     expect(resultForTooHighInitialValue.current.current).toBe(3);
   });
 
   it("is increasable infinitely by default", () => {
-    const { result } = renderHook(() => usePagination({
-      steps: Infinity,
-    }));
+    const { result } = renderHook(() =>
+      usePagination({
+        steps: Infinity,
+      })
+    );
 
     act(() => result.current.next());
     act(() => result.current.next());
-    
+
     expect(result.current.current).toBe(Infinity);
   });
 
   it("is increasable until a defined maximum", () => {
-    const { result } = renderHook(() => usePagination({
-      max: 7,
-      steps: 3,
-    }));
+    const { result } = renderHook(() =>
+      usePagination({
+        max: 7,
+        steps: 3,
+      })
+    );
 
     act(() => result.current.next());
     act(() => result.current.next());
     act(() => result.current.next());
-    
+
     expect(result.current.current).toBe(7);
   });
 
   it("is decreasable until a defined minimum", () => {
-    const { result } = renderHook(() => usePagination({
-      min: 0,
-    }));
+    const { result } = renderHook(() =>
+      usePagination({
+        min: 0,
+      })
+    );
 
     act(() => result.current.prev());
     act(() => result.current.prev());
-    
+
     expect(result.current.current).toBe(0);
   });
 
   it("increases current page by steps on calling exposed helper 'next'", () => {
     const { result: resultForDefaultSetup } = renderHook(() => usePagination());
-    const { result: resultForSetupWithSteps } = renderHook(() => usePagination({
-      steps: 22,
-    }));
-    const { result: resultForSetupWithStepsAndInitialValue } = renderHook(() => usePagination({
-      steps: 99,
-      initial: 20001
-    }));
+    const { result: resultForSetupWithSteps } = renderHook(() =>
+      usePagination({
+        steps: 22,
+      })
+    );
+    const { result: resultForSetupWithStepsAndInitialValue } = renderHook(() =>
+      usePagination({
+        steps: 99,
+        initial: 20001,
+      })
+    );
 
     act(() => resultForDefaultSetup.current.next());
     act(() => resultForSetupWithSteps.current.next());
     act(() => resultForSetupWithStepsAndInitialValue.current.next());
-  
+
     expect(resultForDefaultSetup.current.current).toBe(1);
     expect(resultForSetupWithSteps.current.current).toBe(22);
     expect(resultForSetupWithStepsAndInitialValue.current.current).toBe(20100);
@@ -106,18 +120,22 @@ describe("usePagination", () => {
 
   it("decreases current page by steps on calling exposed helper 'prev'", () => {
     const { result: resultForDefaultSetup } = renderHook(() => usePagination());
-    const { result: resultForSetupWithSteps } = renderHook(() => usePagination({
-      steps: 10,
-    }));
-    const { result: resultForSetupWithStepsAndInitialValue } = renderHook(() => usePagination({
-      steps: 2,
-      initial: 100
-    }));
+    const { result: resultForSetupWithSteps } = renderHook(() =>
+      usePagination({
+        steps: 10,
+      })
+    );
+    const { result: resultForSetupWithStepsAndInitialValue } = renderHook(() =>
+      usePagination({
+        steps: 2,
+        initial: 100,
+      })
+    );
 
     act(() => resultForDefaultSetup.current.prev());
     act(() => resultForSetupWithSteps.current.prev());
     act(() => resultForSetupWithStepsAndInitialValue.current.prev());
-  
+
     expect(resultForDefaultSetup.current.current).toBe(-1);
     expect(resultForSetupWithSteps.current.current).toBe(-10);
     expect(resultForSetupWithStepsAndInitialValue.current.current).toBe(98);
@@ -127,32 +145,36 @@ describe("usePagination", () => {
     const { result } = renderHook(() => usePagination({}));
 
     act(() => result.current.setCurrent(42));
-    
+
     expect(result.current.current).toBe(42);
   });
 
   it("always sets current to closest boundary", () => {
-    const { result } = renderHook(() => usePagination({
-      min: 10,
-      max: 200
-    }));
+    const { result } = renderHook(() =>
+      usePagination({
+        min: 10,
+        max: 200,
+      })
+    );
 
     act(() => result.current.setCurrent(5));
     const valueAfterSetTooLow = result.current.current;
 
     act(() => result.current.setCurrent(599));
     const valueAfterSetTooHigh = result.current.current;
-    
+
     expect(valueAfterSetTooLow).toBe(10);
     expect(valueAfterSetTooHigh).toBe(200);
   });
 
   it("checks if increasable by exposed 'hasNext'", () => {
-    const { result } = renderHook(() => usePagination({
-      initial: 4,
-      steps: 10,
-      max: 6,
-    }));
+    const { result } = renderHook(() =>
+      usePagination({
+        initial: 4,
+        steps: 10,
+        max: 6,
+      })
+    );
 
     const increasableBeforeReachingMax = result.current.hasNext();
     act(() => result.current.next());
@@ -163,9 +185,11 @@ describe("usePagination", () => {
   });
 
   it("checks if decreasable by exposed 'hasPrev'", () => {
-    const { result } = renderHook(() => usePagination({
-      min: 0,
-    }));
+    const { result } = renderHook(() =>
+      usePagination({
+        min: 0,
+      })
+    );
 
     const decreasableIfAtMin = result.current.hasPrev();
     act(() => result.current.setCurrent(20));
@@ -176,9 +200,11 @@ describe("usePagination", () => {
   });
 
   it("compares a given value for equality to current by exposed 'isCurrent'", () => {
-    const { result } = renderHook(() => usePagination({
-      initial: 333,
-    }));
+    const { result } = renderHook(() =>
+      usePagination({
+        initial: 333,
+      })
+    );
 
     expect(result.current.isCurrent(10)).toBe(false);
     expect(result.current.isCurrent(Infinity)).toBe(false);

--- a/packages/use-pagination/src/usePagination.ts
+++ b/packages/use-pagination/src/usePagination.ts
@@ -33,9 +33,12 @@ export const usePagination = ({
   return {
     current,
     isCurrent: (value: number) => value === current,
-    setCurrent: (nextValue: number) => setCurrent(keepValueInsideRange(nextValue)),
-    next: () => setCurrent((value: number) => keepValueInsideRange(value + steps)),
-    prev: () => setCurrent((value: number) => keepValueInsideRange(value - steps)),
+    setCurrent: (nextValue: number) =>
+      setCurrent(keepValueInsideRange(nextValue)),
+    next: () =>
+      setCurrent((value: number) => keepValueInsideRange(value + steps)),
+    prev: () =>
+      setCurrent((value: number) => keepValueInsideRange(value - steps)),
     hasNext: () => current < max,
     hasPrev: () => current > min,
   };

--- a/packages/use-pagination/tsconfig.json
+++ b/packages/use-pagination/tsconfig.json
@@ -4,12 +4,6 @@
     "rootDir": "./src/",
     "outDir": "./lib/esm/"
   },
-  "exclude": [
-    "node_modules",
-    "lib",
-    "src/**/*.spec.ts"
-  ],
-  "include": [
-    "src/**/*.ts"
-  ]
+  "exclude": ["node_modules", "lib", "src/**/*.spec.ts"],
+  "include": ["src/**/*.ts"]
 }

--- a/packages/use-service/README.md
+++ b/packages/use-service/README.md
@@ -34,7 +34,7 @@ pnpm add --save @openformation/use-service
 useService = (
   serviceFactoryFn: (deps: Dependencies) => Service,
   deps: Dependencies
-) => Service
+) => Service;
 ```
 
 `serviceFactoryFn` is a function that takes one argument `Dependencies` and returns a `Service`.
@@ -70,7 +70,10 @@ import { useService } from "@openformation/use-service";
 
 const TodoList: React.FC<{ serviceUri: string }> = (props) => {
   const api = useService(makeApi, { serviceUri: props.serviceUri });
-  const createTodo = React.useCallback(() => api.addTodo({ label: "New Todo" }), [api]);
+  const createTodo = React.useCallback(
+    () => api.addTodo({ label: "New Todo" }),
+    [api]
+  );
 
   /* ... */
 };

--- a/packages/use-service/package.json
+++ b/packages/use-service/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf ./lib && pnpm run build:esm && pnpm run build:cjs",
     "build:esm": "rm -rf ./lib/esm && tsc",
     "build:cjs": "rm -rf ./lib/cjs && tsc -p tsconfig.cjs.json",
+    "clean": "rm -rf ./lib",
     "test": "jest --verbose src/"
   },
   "keywords": [],

--- a/packages/use-service/tsconfig.json
+++ b/packages/use-service/tsconfig.json
@@ -4,12 +4,6 @@
     "rootDir": "./src/",
     "outDir": "./lib/esm/"
   },
-  "exclude": [
-    "node_modules",
-    "lib",
-    "src/**/*.spec.ts"
-  ],
-  "include": [
-    "src/**/*.ts"
-  ]
+  "exclude": ["node_modules", "lib", "src/**/*.spec.ts"],
+  "include": ["src/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,10 @@ importers:
       '@types/jest': ^27.4.1
       '@types/node': ^17.0.23
       '@types/react': ^18.0.1
+      editorconfig-checker: ^4.0.2
+      husky: ^7.0.4
       jest: ^27.5.1
+      lint-staged: ^12.4.0
       prettier: ^2.6.2
       react: ^18.0.0
       react-test-renderer: ^18.0.0
@@ -20,7 +23,10 @@ importers:
       '@types/jest': 27.4.1
       '@types/node': 17.0.23
       '@types/react': 18.0.1
+      editorconfig-checker: 4.0.2
+      husky: 7.0.4
       jest: 27.5.1_ts-node@10.7.0
+      lint-staged: 12.4.0
       prettier: 2.6.2
       react: 18.0.0
       react-test-renderer: 18.0.0_react@18.0.0
@@ -818,6 +824,14 @@ packages:
       - supports-color
     dev: true
 
+  /aggregate-error/3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    dev: true
+
   /ansi-escapes/4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -828,6 +842,11 @@ packages:
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /ansi-regex/6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
     dev: true
 
   /ansi-styles/3.2.1:
@@ -849,6 +868,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /ansi-styles/6.1.0:
+    resolution: {integrity: sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==}
+    engines: {node: '>=12'}
+    dev: true
+
   /anymatch/3.1.2:
     resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
     engines: {node: '>= 8'}
@@ -865,6 +889,11 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
+    dev: true
+
+  /astral-regex/2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /asynckit/0.4.0:
@@ -1036,12 +1065,45 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /chownr/2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+    dev: true
+
   /ci-info/3.3.0:
     resolution: {integrity: sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==}
     dev: true
 
   /cjs-module-lexer/1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+    dev: true
+
+  /clean-stack/2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /cli-cursor/3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+    dependencies:
+      restore-cursor: 3.1.0
+    dev: true
+
+  /cli-truncate/2.1.0:
+    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
+    engines: {node: '>=8'}
+    dependencies:
+      slice-ansi: 3.0.0
+      string-width: 4.2.3
+    dev: true
+
+  /cli-truncate/3.1.0:
+    resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 5.1.2
     dev: true
 
   /cliui/7.0.4:
@@ -1082,11 +1144,20 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /colorette/2.0.16:
+    resolution: {integrity: sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==}
+    dev: true
+
   /combined-stream/1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+    dev: true
+
+  /commander/8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
     dev: true
 
   /concat-map/0.0.1:
@@ -1152,6 +1223,19 @@ packages:
       ms: 2.1.2
     dev: true
 
+  /debug/4.3.4_supports-color@9.2.2:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+      supports-color: 9.2.2
+    dev: true
+
   /decimal.js/10.3.1:
     resolution: {integrity: sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==}
     dev: true
@@ -1196,6 +1280,22 @@ packages:
       webidl-conversions: 5.0.0
     dev: true
 
+  /eastasianwidth/0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
+
+  /editorconfig-checker/4.0.2:
+    resolution: {integrity: sha512-tUI7ABIzMB1kfwTUQmX+gaZGCMNuUgGuRHJ+Xu4Tk9T8lV8Vy5w/EaQsSZ7NKrOgLxbekptw6MUgrzHTvhceLw==}
+    hasBin: true
+    dependencies:
+      https-proxy-agent: 5.0.0
+      node-fetch: 2.6.7
+      tar: 6.1.11
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
   /electron-to-chromium/1.4.106:
     resolution: {integrity: sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==}
     dev: true
@@ -1207,6 +1307,10 @@ packages:
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /emoji-regex/9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
 
   /error-ex/1.3.2:
@@ -1327,6 +1431,13 @@ packages:
       mime-types: 2.1.35
     dev: true
 
+  /fs-minipass/2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.1.6
+    dev: true
+
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
     dev: true
@@ -1437,6 +1548,12 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
+  /husky/7.0.4:
+    resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
+    engines: {node: '>=12'}
+    hasBin: true
+    dev: true
+
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -1456,6 +1573,11 @@ packages:
   /imurmurhash/0.1.4:
     resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
     engines: {node: '>=0.8.19'}
+    dev: true
+
+  /indent-string/4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
     dev: true
 
   /inflight/1.0.6:
@@ -1482,6 +1604,11 @@ packages:
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /is-fullwidth-code-point/4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /is-generator-fn/2.1.0:
@@ -2112,8 +2239,55 @@ packages:
       type-check: 0.3.2
     dev: true
 
+  /lilconfig/2.0.4:
+    resolution: {integrity: sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: true
+
+  /lint-staged/12.4.0:
+    resolution: {integrity: sha512-3X7MR0h9b7qf4iXf/1n7RlVAx+EzpAZXoCEMhVSpaBlgKDfH2ewf+QUm7BddFyq29v4dgPP+8+uYpWuSWx035A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      cli-truncate: 3.1.0
+      colorette: 2.0.16
+      commander: 8.3.0
+      debug: 4.3.4_supports-color@9.2.2
+      execa: 5.1.1
+      lilconfig: 2.0.4
+      listr2: 4.0.5
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-inspect: 1.12.0
+      pidtree: 0.5.0
+      string-argv: 0.3.1
+      supports-color: 9.2.2
+      yaml: 1.10.2
+    transitivePeerDependencies:
+      - enquirer
+    dev: true
+
+  /listr2/4.0.5:
+    resolution: {integrity: sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      enquirer: '>= 2.3.0 < 3'
+    peerDependenciesMeta:
+      enquirer:
+        optional: true
+    dependencies:
+      cli-truncate: 2.1.0
+      colorette: 2.0.16
+      log-update: 4.0.0
+      p-map: 4.0.0
+      rfdc: 1.3.0
+      rxjs: 7.5.5
+      through: 2.3.8
+      wrap-ansi: 7.0.0
     dev: true
 
   /locate-path/5.0.0:
@@ -2129,6 +2303,16 @@ packages:
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
+  /log-update/4.0.0:
+    resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-escapes: 4.3.2
+      cli-cursor: 3.1.0
+      slice-ansi: 4.0.0
+      wrap-ansi: 6.2.0
     dev: true
 
   /loose-envify/1.4.0:
@@ -2195,12 +2379,45 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /minipass/3.1.6:
+    resolution: {integrity: sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      yallist: 4.0.0
+    dev: true
+
+  /minizlib/2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.1.6
+      yallist: 4.0.0
+    dev: true
+
+  /mkdirp/1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
+    dev: true
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
     dev: true
 
   /node-int64/0.4.0:
@@ -2230,6 +2447,10 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /object-inspect/1.12.0:
+    resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
     dev: true
 
   /once/1.4.0:
@@ -2269,6 +2490,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
+    dev: true
+
+  /p-map/4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      aggregate-error: 3.1.0
     dev: true
 
   /p-try/2.2.0:
@@ -2316,6 +2544,12 @@ packages:
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
+
+  /pidtree/0.5.0:
+    resolution: {integrity: sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==}
+    engines: {node: '>=0.10'}
+    hasBin: true
     dev: true
 
   /pirates/4.0.5:
@@ -2448,11 +2682,29 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
+  /restore-cursor/3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+    dev: true
+
+  /rfdc/1.3.0:
+    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
+    dev: true
+
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
     dependencies:
       glob: 7.2.0
+    dev: true
+
+  /rxjs/7.5.5:
+    resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
+    dependencies:
+      tslib: 2.4.0
     dev: true
 
   /safe-buffer/5.1.2:
@@ -2514,6 +2766,32 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /slice-ansi/3.0.0:
+    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+    dev: true
+
+  /slice-ansi/4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+    dev: true
+
+  /slice-ansi/5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.1.0
+      is-fullwidth-code-point: 4.0.0
+    dev: true
+
   /source-map-support/0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
@@ -2547,6 +2825,11 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /string-argv/0.3.1:
+    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
+    engines: {node: '>=0.6.19'}
+    dev: true
+
   /string-length/4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -2564,11 +2847,27 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
+  /string-width/5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.0.1
+    dev: true
+
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+    dev: true
+
+  /strip-ansi/7.0.1:
+    resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.0.1
     dev: true
 
   /strip-bom/4.0.0:
@@ -2607,6 +2906,11 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /supports-color/9.2.2:
+    resolution: {integrity: sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==}
+    engines: {node: '>=12'}
+    dev: true
+
   /supports-hyperlinks/2.2.0:
     resolution: {integrity: sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==}
     engines: {node: '>=8'}
@@ -2622,6 +2926,18 @@ packages:
 
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: true
+
+  /tar/6.1.11:
+    resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
+    engines: {node: '>= 10'}
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 3.1.6
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
     dev: true
 
   /terminal-link/2.1.1:
@@ -2643,6 +2959,10 @@ packages:
 
   /throat/6.0.1:
     resolution: {integrity: sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==}
+    dev: true
+
+  /through/2.3.8:
+    resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
     dev: true
 
   /tmpl/1.0.5:
@@ -2668,6 +2988,10 @@ packages:
       psl: 1.8.0
       punycode: 2.1.1
       universalify: 0.1.2
+    dev: true
+
+  /tr46/0.0.3:
+    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
     dev: true
 
   /tr46/2.1.0:
@@ -2742,6 +3066,10 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: true
+
   /type-check/0.3.2:
     resolution: {integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=}
     engines: {node: '>= 0.8.0'}
@@ -2808,6 +3136,10 @@ packages:
       makeerror: 1.0.12
     dev: true
 
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    dev: true
+
   /webidl-conversions/5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
@@ -2826,6 +3158,13 @@ packages:
 
   /whatwg-mimetype/2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
+    dev: true
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: true
 
   /whatwg-url/8.7.0:
@@ -2848,6 +3187,15 @@ packages:
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /wrap-ansi/6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
     dev: true
 
   /wrap-ansi/7.0.0:
@@ -2896,6 +3244,15 @@ packages:
   /y18n/5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
+
+  /yaml/1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
     dev: true
 
   /yargs-parser/20.2.9:

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# Builds all packages
+#
+# Usage:
+#
+# ````sh
+# scripts/build
+# ````
+#
+
+echo "🛠 Building all packages..."
+
+pnpm recursive run --stream build
+
+echo "✅ All packages were built sucessfully."

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# Removes all build artifacts
+#
+# Usage:
+#
+# ````sh
+# scripts/build
+# ````
+#
+
+echo "🗑 Removing all build artifacts..."
+
+pnpm run -r --stream clean
+
+echo "✅ All build artifacts were removed sucessfully."

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# Lint all source files
+#
+# Usage:
+#
+# ````sh
+# scripts/lint
+# ````
+#
+
+echo "🧐 Linting all source files..."
+
+editorconfig-checker
+prettier --check "**/*.{ts,tsx,js,json,css,md}" --ignore-path .gitignore
+
+echo "✅ All source files are 👌."

--- a/scripts/nuke
+++ b/scripts/nuke
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# Removes all build artifacts AND
+# removes all `node_modules`, both global and per-package.
+#
+# Usage:
+#
+# ````sh
+# scripts/nuke
+# ````
+#
+
+echo "💣 Nuking ..."
+
+pnpm clean
+
+echo "📦 Removing all local node_modules ..."
+find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
+
+echo "✅ Local environment was reset. Run 'pnpm install' to prepare the local environment again."

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# Runs unit tests in all packages
+#
+# Usage:
+#
+# ````sh
+# scripts/test
+# ````
+#
+
+echo "🎯 Running unit tests in all packages..."
+
+pnpm recursive run --stream test
+
+echo "✅ All unit tests are green."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,7 @@
       "@openformation/*": ["packages/*/src"]
     },
     "jsx": "react",
-    "lib": [
-      "ESNext",
-      "DOM"
-    ],
+    "lib": ["ESNext", "DOM"],
     "strict": true,
     "sourceMap": true,
     "esModuleInterop": true,
@@ -31,5 +28,5 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "skipLibCheck": true
-  },
+  }
 }


### PR DESCRIPTION
This PR adds linting via `editorconfig-checker` and `prettier`.

Furthermore, it externalizes all package.json scripts to a `scripts/` directory and adds a `clean` and a `nuke` script.